### PR TITLE
Feature/print errors at the end

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Snippet from a package.json:
   "scripts": {
     "test": "nyc blue-tape test/**/*.js | tap-nirvana "
   }
+
+  Options:
+
+    --failedLast
+      Print failed assertions at the end of the stream
 ```
 
-### Options
-
-```
-  --errorsLast: print errors at the end of the stream
-```
 ### Features:
 
 1. Color-coded diffs of complex objects for easy expected/actual analysis

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Snippet from a package.json:
   }
 ```
 
+### Options
+
+```
+  --errorsLast: print errors at the end of the stream
+```
 ### Features:
 
 1. Color-coded diffs of complex objects for easy expected/actual analysis

--- a/tap-nirvana.js
+++ b/tap-nirvana.js
@@ -61,10 +61,10 @@ function removeUselessStackLines(stack) {
 module.exports = function (spec) {
 
   const args = process.argv.slice(2);
-  let errorsLast = false;
+  let failedLast = false;
   
-  if(args[0]==="--errorsLast"){
-    errorsLast = true;
+  if(args[0]==="--failedLast"){
+    failedLast = true;
   }
 
   spec = spec || {};
@@ -113,7 +113,7 @@ module.exports = function (spec) {
     }
 
     if (results.fail.length > 0) {
-      if(errorsLast){
+      if(failedLast){
         output.push(formatErrors(results));
       }
       output.push('\n');

--- a/tap-nirvana.js
+++ b/tap-nirvana.js
@@ -94,7 +94,7 @@ module.exports = function (spec) {
 
   // Failing assertions
   parser.on('fail', function (assertion) {
-    output.push(formatError(assertion))
+    output.push(formatFailedAssertion(assertion))
 
     stream.failed = true;
   });
@@ -114,11 +114,11 @@ module.exports = function (spec) {
 
     if (results.fail.length > 0) {
       if(errorsLast){
-        output.push(formatFailedAssertions(results));
+        output.push(formatErrors(results));
       }
       output.push('\n');
     }
-    // failingTests.forEach(s => output.push(s));
+
     output.push(formatTotals(results));
     output.push('\n');
 
@@ -148,9 +148,7 @@ module.exports = function (spec) {
     return pretty;
   }
 
-  // this duplicates errors that we already showd.
-  // @TODO : remove
-  function formatError (assertion) {
+  function formatFailedAssertion (assertion) {
     
     var glyph = symbols.cross;
     var title =  glyph + pad(assertion.name);
@@ -218,7 +216,7 @@ module.exports = function (spec) {
            pad(format.dim('(' + prettyMs(new Date().getTime() - startTime) + ')'));
   }
 
-  function formatFailedAssertions (results) {
+  function formatErrors (results) {
 
     var out = '';
 
@@ -234,7 +232,7 @@ module.exports = function (spec) {
 
       // Write failed assertion
       _.each(assertions, function (assertion) {
-        out += formatError(assertion);
+        out += formatFailedAssertion(assertion);
       });
 
       out += '\n';


### PR DESCRIPTION
## Motivation

Some time there is a long list of tests and it might be inconvenient to scroll up to check which tests fail.

This pr allows users to specify an option to print errors at the end of the stream